### PR TITLE
Add Plone 5.1 compatibility.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.3 (unreleased)
 ----------------
 
+- Add Plone 5.1 compatibility. [phgross]
+
 - Drop support for Plone 4.0 and 4.1. [jone]
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'Framework :: Plone',
         'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
+        'Framework :: Plone :: 5.1',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
         ],

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
+
+package-name = ftw.dictstorage


### PR DESCRIPTION
Note: The package is currently not tested really well.  Maybe we should wait until we add Plone 5 compatibility to ftw.table before merge. 